### PR TITLE
Make runnable on Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # PythonForRUsers
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/poldrack/PythonForRUsers/master?filepath=notebooks)
+
 Notebooks to introduce R users to Python
 
 *NOTE*: This is a work in progress!

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+dependencies:
+  - numpy<1.18  # seaborn breaks on new numpy, so restrict until new release
+  - pandas
+  - statsmodels
+  - matplotlib
+  - seaborn
+  - rpy2
+  - r-dplyr
+  - r-knitr
+  - r-readr


### PR DESCRIPTION
This repository currently assumes that you know how to get Jupyter notebooks running. I imagine this is covered in a course, but a brief start-up would be great to have in a README. Though that's not what this PR is...

A good way to make sure that you give users a clear path to getting going is to enable [Binder](https://mybinder.readthedocs.io/en/latest/introduction.html#preparing-a-repository-for-binder), which creates a new environment from scratch when started up.