### PR TITLE
FIX: Add r-tidyr to environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - r-dplyr
   - r-knitr
   - r-readr
+  - r-tidyr


### PR DESCRIPTION
Went through the binder and found notebook 5 was still having an issue. Looks like I missed an R package.